### PR TITLE
Fix screen query for toppingsTotal in reset test

### DIFF
--- a/finished-projects/sundaes-on-demand/src/tests/orderPhase.test.jsx
+++ b/finished-projects/sundaes-on-demand/src/tests/orderPhase.test.jsx
@@ -88,7 +88,7 @@ test('Order phases for happy path', async () => {
   // check that scoops and toppings have been reset
   const scoopsTotal = screen.getByText('Scoops total: $0.00');
   expect(scoopsTotal).toBeInTheDocument();
-  const toppingsTotal = screen.getByText('Scoops total: $0.00');
+  const toppingsTotal = screen.getByText('Toppings total: $0.00');
   expect(toppingsTotal).toBeInTheDocument();
 
   // wait for items to appear so that Testing Library doesn't get angry about stuff


### PR DESCRIPTION
This fixes a small copy/paste mistake in the `orderPhase` test.
Great course! Thank you!