### PR TITLE
fixing README instructions

### DIFF
--- a/sundae-starter/README.md
+++ b/sundae-starter/README.md
@@ -109,7 +109,7 @@ Then Add this property / value to the top-level `module.exports` object:
 
 ## Update a few ESLint rules
 
-Add these to the `rules` array in _.eslintrc.cjs_:
+Add these to the `rules` object in _.eslintrc.cjs_:
 
 ```js
     "no-unused-vars": "warn", // warning, not error


### PR DESCRIPTION
The original instruction "Add these to the `rules` array in `_.eslintrc.cjs_`" tripped me up. I thought I was supposed to add to the nested array within `rules`. The one that's the value of `"react-refresh/only-export-components"`

I think changing the instruction to "Add these to the `rules` object..." will clarify where the new key/value pairs need to go.