### PR TITLE
Fix incorrect directory path in README setup instructions

### DIFF
--- a/vite-starter/README.md
+++ b/vite-starter/README.md
@@ -80,7 +80,7 @@ Update _vite.config.js_ based on the [Vitest Testing Library example](https://gi
     globals: true,
     environment: "jsdom",
     // this points to the setup file that we created earlier
-    setupFiles: "./test/setup.js",
+    setupFiles: "./src/setupTests.js",
     // you might want to disable it, if you don't have tests that rely on CSS
     // since parsing CSS is slow
     css: true,


### PR DESCRIPTION
The setupFiles directory of the vite.config.js pointed to a wrong file. The correct file has been added.